### PR TITLE
Increase md button size on mobile for easier tapping

### DIFF
--- a/src/ui/Btn.tsx
+++ b/src/ui/Btn.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode, MouseEventHandler } from 'react';
+import { useIsMobile } from '../hooks/useIsMobile';
 import { theme } from './theme';
 
 interface BtnProps {
@@ -17,6 +18,12 @@ const SIZES = {
   lg: { pad: '12px 24px', fs: 15 },
 } as const;
 
+const SIZES_MOBILE = {
+  sm: { pad: '4px 10px', fs: 11 },
+  md: { pad: '12px 22px', fs: 15 },
+  lg: { pad: '12px 24px', fs: 15 },
+} as const;
+
 export function Btn({
   children,
   onClick,
@@ -26,7 +33,8 @@ export function Btn({
   title,
   type = 'button',
 }: BtnProps) {
-  const s = SIZES[size];
+  const mobile = useIsMobile();
+  const s = mobile ? SIZES_MOBILE[size] : SIZES[size];
   return (
     <button
       type={type}


### PR DESCRIPTION
On screens narrower than 600px, size="md" buttons now use larger padding
(12px 22px) and font-size (15px) to meet touch-target guidelines.

https://claude.ai/code/session_01GpH6EuGF9zEx5fdds8kei4